### PR TITLE
Allow @sentry/browser@>=7.87

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript": "^5.1.6"
   },
   "peerDependencies": {
-    "@sentry/browser": ">= 8.0.0",
+    "@sentry/browser": ">= 7.87.0",
     "zustand": ">= 4.0.0"
   },
   "packageManager": "pnpm@9.2.0+sha512.98a80fd11c2e7096747762304106432b3ddc67dcf54b5a8c01c93f68a2cd5e05e6821849522a06fb76284d41a2660d5e334f2ee3bbf29183bf2e739b1dafa771"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@sentry/browser':
-        specifier: '>= 8.0.0'
+        specifier: '>= 7.87.0'
         version: 8.8.0
       zustand:
         specifier: '>= 4.0.0'


### PR DESCRIPTION
Allow peerDepedency @sentry/browser@>=7.87
This is a version where `getCurrentScope` has been added at top level

Reference: https://github.com/getsentry/sentry-javascript/releases/tag/7.87.0