### PR TITLE
Remove PopArgument ts utility type

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,6 @@
 import type { StateCreator, StoreMutatorIdentifier } from 'zustand';
 import * as Sentry from '@sentry/browser';
 
-type PopArgument<T extends (...a: never[]) => unknown> = T extends (
-  ...a: [...infer A, infer _]
-) => infer R
-  ? (...a: A) => R
-  : never;
-
 interface SentryMiddlewareConfig<T> {
   /**
    * A function that takes the current state as parameter and return the state that will be stored on Sentry.
@@ -24,9 +18,9 @@ type SentryMiddleware = <
 ) => StateCreator<T, Mps, Mcs>;
 
 type SentryMiddlewareImpl = <T extends object>(
-  f: PopArgument<StateCreator<T>>,
+  f: StateCreator<T>,
   config?: SentryMiddlewareConfig<T>,
-) => PopArgument<StateCreator<T>>;
+) => StateCreator<T>;
 
 /**
  * A Sentry middleware for zustand that will store the latest state in Sentry's context.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "@sentry/browser": ">= 7.87.0",
-    "zustand": ">= 4.0.0"
+    "zustand": ">= 4.1.3"
   },
   "packageManager": "pnpm@9.2.0+sha512.98a80fd11c2e7096747762304106432b3ddc67dcf54b5a8c01c93f68a2cd5e05e6821849522a06fb76284d41a2660d5e334f2ee3bbf29183bf2e739b1dafa771"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: '>= 7.87.0'
         version: 8.8.0
       zustand:
-        specifier: '>= 4.0.0'
-        version: 4.1.1(react@18.2.0)
+        specifier: '>= 4.1.3'
+        version: 4.1.3(react@18.2.0)
     devDependencies:
       '@types/jest':
         specifier: ^29.5.3
@@ -2592,8 +2592,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zustand@4.1.1:
-    resolution: {integrity: sha512-h4F3WMqsZgvvaE0n3lThx4MM81Ls9xebjvrABNzf5+jb3/03YjNTSgZXeyrvXDArMeV9untvWXRw1tY+ntPYbA==}
+  zustand@4.1.3:
+    resolution: {integrity: sha512-AdFyr6+4sVD6xlyc/ArQaOrleqzxJEBbAXglufZ5lgvisoz8GUN3icOrKOnX1uRSxmpmdVUQPen9hhymWIzhBg==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
       immer: '>=9.0'
@@ -5587,7 +5587,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zustand@4.1.1(react@18.2.0):
+  zustand@4.1.3(react@18.2.0):
     dependencies:
       use-sync-external-store: 1.2.0(react@18.2.0)
     optionalDependencies:


### PR DESCRIPTION
There is no need to use `PopArgument` since zustand >= 4.1.3, which is now set to new minimum requirement
See https://github.com/pmndrs/zustand/pull/1373