### PR TITLE
Feature: Handle store.setState

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,15 +1,17 @@
 import type { StateCreator, StoreMutatorIdentifier } from 'zustand';
 import * as Sentry from '@sentry/browser';
 
+type Context = Record<string, unknown>;
+
 interface SentryMiddlewareConfig<T> {
   /**
    * A function that takes the current state as parameter and return the state that will be stored on Sentry.
    */
-  stateTransformer?: (state: T) => object;
+  stateTransformer?: (state: T) => Context;
 }
 
 type SentryMiddleware = <
-  T extends object,
+  T,
   Mps extends [StoreMutatorIdentifier, unknown][] = [],
   Mcs extends [StoreMutatorIdentifier, unknown][] = [],
 >(
@@ -17,7 +19,7 @@ type SentryMiddleware = <
   config?: SentryMiddlewareConfig<T>,
 ) => StateCreator<T, Mps, Mcs>;
 
-type SentryMiddlewareImpl = <T extends object>(
+type SentryMiddlewareImpl = <T extends Context>(
   f: StateCreator<T>,
   config?: SentryMiddlewareConfig<T>,
 ) => StateCreator<T>;

--- a/tests/sentryMiddleware.spec.ts
+++ b/tests/sentryMiddleware.spec.ts
@@ -67,4 +67,17 @@ describe('sentryMiddleware', () => {
       },
     });
   });
+
+  // https://github.com/pmndrs/zustand?tab=readme-ov-file#using-zustand-without-react
+  test("adds the state to sentry's context using store.setState", () => {
+    store.setState({ bears: 1 });
+
+    expect(setContextMock).toHaveBeenCalledWith('state', {
+      state: {
+        type: 'zustand',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        value: { bears: 1, increase: expect.any(Function) },
+      },
+    });
+  });
 });


### PR DESCRIPTION
This adds support for using zustand [without React](https://github.com/pmndrs/zustand?tab=readme-ov-file#using-zustand-without-react) by calling `store.setState` directly

I based this change on Zustand Recipe: [Middleware that doesn't change the store type
](https://github.com/pmndrs/zustand/blob/v5.0.1/docs/guides/typescript.md#middleware-that-doesnt-change-the-store-type)

Note: Docs say that middlewares are not applied in this case, but it seems to not be true - new test is passing